### PR TITLE
Fix booleans conversion

### DIFF
--- a/src/main/java/com/soarex/truffle/lama/LamaTypeSystem.java
+++ b/src/main/java/com/soarex/truffle/lama/LamaTypeSystem.java
@@ -5,10 +5,11 @@ import com.oracle.truffle.api.dsl.TypeSystem;
 
 @TypeSystem({boolean.class, int.class})
 public class LamaTypeSystem {
-//    @ImplicitCast
-//    public static boolean castIntToBoolean(int value) {
-//        return value != 0;
-//    }
+
+    @ImplicitCast
+    public static boolean castIntToBoolean(int value) {
+        return value != 0;
+    }
 
     @ImplicitCast
     public static int castBooleanToInt(boolean value) {

--- a/src/main/java/com/soarex/truffle/lama/nodes/variables/WriteLocalVariableNode.java
+++ b/src/main/java/com/soarex/truffle/lama/nodes/variables/WriteLocalVariableNode.java
@@ -1,5 +1,6 @@
 package com.soarex.truffle.lama.nodes.variables;
 
+import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -8,6 +9,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.soarex.truffle.lama.nodes.LamaNode;
 
+@SuppressWarnings("unused")
 @NodeInfo(shortName = "write(local)")
 @NodeChild("value")
 @NodeField(name = "slot", type = int.class)
@@ -28,7 +30,7 @@ public abstract class WriteLocalVariableNode extends LamaNode {
         return value;
     }
 
-    @Specialization(replaces = {"writeBoolean", "writeInt"})
+    @Fallback
     protected Object write(VirtualFrame frame, Object value) {
         frame.getFrameDescriptor().setSlotKind(getSlot(), FrameSlotKind.Object);
         frame.setObject(getSlot(), value);
@@ -37,7 +39,7 @@ public abstract class WriteLocalVariableNode extends LamaNode {
 
     protected boolean isBooleanOrIllegal(VirtualFrame frame) {
         final FrameSlotKind kind = frame.getFrameDescriptor().getSlotKind(getSlot());
-        return kind == FrameSlotKind.Boolean || kind == FrameSlotKind.Illegal;
+        return kind == FrameSlotKind.Boolean;
     }
 
     protected boolean isIntOrIllegal(VirtualFrame frame) {


### PR DESCRIPTION
FrameSlot is always Illegal initially so conversion to boolean always happens as for the first specialization 